### PR TITLE
work around memory leak

### DIFF
--- a/routes/circularize.js
+++ b/routes/circularize.js
@@ -60,7 +60,7 @@ router.get('/', function(req, res) {
         }
         res.send(buf);
 
-        // workaround leak https://github.com/Automattic/node-canvas/issues/785
+        // leak workaround https://github.com/Automattic/node-canvas/issues/785
         img.onload = null;
         img.onerror = null;
         img.src = null;

--- a/routes/circularize.js
+++ b/routes/circularize.js
@@ -53,7 +53,19 @@ router.get('/', function(req, res) {
       res.setHeader('content-type', 'image/png');
       res.setHeader('cache-control', 'max-age=86400');
 
-      canvas.pngStream().pipe(res);
+      canvas.toBuffer(function (err, buf) {
+        if (err) {
+          res.status(500).send('Unable to read image');
+          return;
+        }
+        res.send(buf);
+
+        // workaround leak https://github.com/Automattic/node-canvas/issues/785
+        img.onload = null;
+        img.onerror = null;
+        img.src = null;
+      });
+
     };
 
     img.onerror = function () {


### PR DESCRIPTION
Referenced ticket from code: https://github.com/Automattic/node-canvas/issues/785

Tested command: `ab -n 10000 -c 50 "http://localhost:3000/circularize/?src=http%3A%2F%2Flocalhost%3A3000%2F%3Ftext%3Dds%26seed%3D1"`

Memory before:
![mem-before](https://cloud.githubusercontent.com/assets/44259/17863667/6f6dc266-684f-11e6-8f26-303aa347808a.png)

```
Percentage of the requests served within a certain time (ms)
50%    334
66%    346
75%    353
80%    358
90%    373
95%    388
98%    405
99%    428
100%    494 (longest request)
```

Memory after:
![mem-after](https://cloud.githubusercontent.com/assets/44259/17863719/b0dc39d0-684f-11e6-98b6-b35c98ee4f13.png)

```
Percentage of the requests served within a certain time (ms)
    50%    317
    66%    324
    75%    328
    80%    332
    90%    350
    95%    366
    98%    382
    99%    392
    100%    795 (longest request)
```

@diwu1989 
@BetterWorks/enterprise 